### PR TITLE
menu.php ignores $item->anchor_css

### DIFF
--- a/plugins/system/core/classes/menu.php
+++ b/plugins/system/core/classes/menu.php
@@ -413,11 +413,10 @@ class Helix3Menu {
 	}
 
 	private function item($item, $extra_class=''){
-		$class = $extra_class;
 		$title = $item->anchor_title ? 'title="' . $item->anchor_title . '" ' : '';
 
-		$item->anchor_css = ($item->anchor_css) ? ' ' . $item->anchor_css : '';
-		$class = ($class) ? 'class="' . $class . $item->anchor_css . '" ' : '';
+		$class = trim($extra_class . ' ' . $item->anchor_css);
+		$class = ($class) ? 'class="' . $class . '"' : '';
 
 		if ($item->menu_image)
 		{


### PR DESCRIPTION
I filled fields *Link CSS Style* in menu items but entered classes are all ignored because
```
$item->anchor_css
```
is only respected when $extra_class is not empty.