### PR TITLE
Pagetitle is shown incorrectly

### DIFF
--- a/template/html/com_content/article/default.php
+++ b/template/html/com_content/article/default.php
@@ -36,7 +36,6 @@ if(isset($article_attribs->spfeatured_image) && $article_attribs->spfeatured_ima
 
 //opengraph
 $document = JFactory::getDocument();
-$document->setTitle($this->item->title);
 $document->addCustomTag('<meta property="og:url" content="'.JURI::current().'" />');
 $document->addCustomTag('<meta property="og:type" content="article" />');
 $document->setDescription( JHtml::_('string.truncate', $this->item->introtext, 155, false, false ) );


### PR DESCRIPTION
The line broke the <title>-tag.
Removing this line let us show the pagetitle correctly again.
Fixes #59 