### PR TITLE
update main.js - tooltip - data toggle attribute

### DIFF
--- a/templates/shaper_helix3/js/main.js
+++ b/templates/shaper_helix3/js/main.js
@@ -195,7 +195,7 @@ jQuery(function ($) {
 	// **************************************************** //
 
 	//Tooltip
-	var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-toggle="tooltip"]'));
+	var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
 	var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
 		return new bootstrap.Tooltip(tooltipTriggerEl);
 	});


### PR DESCRIPTION
Since Helix3 has been upgraded to Bootstrap v5, it needs the correct data toggle for the tooltip initialization.  data-bs-toggle